### PR TITLE
added __clone method - cloning nested forms

### DIFF
--- a/src/CompositeForm.php
+++ b/src/CompositeForm.php
@@ -174,4 +174,24 @@ abstract class CompositeForm extends Model
     {
         return isset($this->_forms[$name]) || parent::__isset($name);
     }
+    
+    public function __clone()
+	{
+		$clonedForms = [];
+		foreach ($this->_forms as $key => $form)
+		{
+			if (is_array($form))
+			{
+				foreach ($form as $formKey => $deepForm)
+				{
+					$clonedForms[$key][$formKey] = clone $deepForm;
+				}
+			}
+			else
+			{
+				$clonedForms[$key] = clone $form;
+			}
+		}
+		$this->_forms = $clonedForms;
+	}
 }


### PR DESCRIPTION
// this is to avoid this problem

```
$originalCompositeForm = new MyCompositeForm();
$nestedForm = new TitleForm();
$nestedForm->name = 'original';
$originalCompositeForm->titleForms = [$nestedForm];

echo $originalCompositeForm->titleForms[0]->name; //  'original'

$newCompositeForm = clone $originalCompositeForm;
$newCompositeForm ->titleForms[0]->name = 'new name';

echo $newCompositeForm ->titleForms[0]->name; //  'new name'
echo $originalCompositeForm->titleForms[0]->name; //  'new name' (but 'original' is expected)
```